### PR TITLE
Adds support for building with Qt Creator 4.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Windows Builds: [![Build status](https://ci.appveyor.com/api/projects/status/6lu
 Qt Creator Plugin for communication with [Sourcetrail](https://sourcetrail.com)
 
 Supported Qt Creator Versions:
+* Qt Creator 4.7.x
 * Qt Creator 4.4.x
 * Qt Creator 4.3.x
 * Qt Creator 4.2.x

--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 if [ ! -d "qt-src" ]; then
-curl -fsSL "http://download.qt.io/official_releases/qtcreator/4.2/4.2.0/installer_source/linux_gcc_64_rhel66/qtcreator_dev.7z" -o qt-dev.7z
+curl -fsSL "http://download.qt.io/official_releases/qtcreator/4.7/4.7.0/installer_source/linux_gcc_64_rhel72/qtcreator_dev.7z" -o qt-dev.7z
 7z x -y qt-dev.7z -o"qt-src"
 rm qt-dev.7z
 fi
 if [ ! -d "qt-bin" ]; then
-curl -fsSL "http://download.qt.io/official_releases/qtcreator/4.2/4.2.0/installer_source/linux_gcc_64_rhel66/qtcreator.7z" -o qt-bin.7z
+curl -fsSL "http://download.qt.io/official_releases/qtcreator/4.7/4.7.0/installer_source/linux_gcc_64_rhel72/qtcreator.7z" -o qt-bin.7z
 7z x -y qt-bin.7z -o"qt-bin"
 rm qt-bin.7z
 fi

--- a/src/sourcetrailplugin.cpp
+++ b/src/sourcetrailplugin.cpp
@@ -34,7 +34,6 @@
 #include <QStatusBar>
 #include <QPushButton>
 #include <coreplugin/infobar.h>
-#include <coreplugin/statusbarwidget.h>
 
 using namespace Core;
 
@@ -53,12 +52,6 @@ SourcetrailPlugin::SourcetrailPlugin()
 			this->handleMessage(QString::fromLatin1(connection->readAll()));
 		});
 	});
-
-//	m_statusBar = new StatusBarWidget();
-//	m_statusBar->setWidget(new QLabel("Test"));
-//	m_statusBar->setPosition(StatusBarWidget::LastLeftAligned);
-//	addAutoReleasedObject(m_statusBar);
-
 }
 
 void SourcetrailPlugin::handleMessage(QString message)
@@ -106,7 +99,6 @@ bool SourcetrailPlugin::initialize(const QStringList &arguments, QString *errorS
 	Q_UNUSED(errorString)
 
 	m_page = new SourceTrailPluginSettingsPage(this);
-	addAutoReleasedObject(m_page);
 	connect(m_page, &SourceTrailPluginSettingsPage::SourceTrailPluginSettingsChanged,
 			this, &SourcetrailPlugin::restartServer);
 


### PR DESCRIPTION
Bumps the Qt Creator release used to build with to version 4.7.
Removes include of coreplugin/statusbarwidget.h since that file is not
used and not present in 4.7, also removes the commented out code that
refers to this.
Removes call to addAutoReleasedObject since that function is no longer
there.