### PR TITLE
Update qtc version support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,20 +13,38 @@ environment:
   BINTRAY_KEY:
     secure: 64COF2Ng3AdKqw6BEQqhlTu8G1j0F43qv6zZ6tg4VLbVCxXBxB2kW42COoqSiBJA
   matrix:
-    - platform: x86  
+    - platform: x86
       QTC_VER: 4.2
       
-    - platform: x86  
+    - platform: x86
       QTC_VER: 4.3
       
-    - platform: x64  
+    - platform: x64
       QTC_VER: 4.3
     
-    - platform: x86  
+    - platform: x86
       QTC_VER: 4.4
     
-    - platform: x64  
+    - platform: x64
       QTC_VER: 4.4
+    
+    - platform: x86
+      QTC_VER: 4.5
+    
+    - platform: x64
+      QTC_VER: 4.5
+    
+    - platform: x86
+      QTC_VER: 4.6
+    
+    - platform: x64
+      QTC_VER: 4.6
+    
+    - platform: x86
+      QTC_VER: 4.7
+    
+    - platform: x64
+      QTC_VER: 4.7
 
 configuration:
   - Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,21 @@ matrix:
           sudo: required
           dist: trusty
           env: QTC_VER=4.4 QTC_DL=linux_gcc_64_rhel72
+        - os: linux
+          compiler: gcc
+          sudo: required
+          dist: trusty
+          env: QTC_VER=4.5 QTC_DL=linux_gcc_64_rhel72
+        - os: linux
+          compiler: gcc
+          sudo: required
+          dist: trusty
+          env: QTC_VER=4.6 QTC_DL=linux_gcc_64_rhel72
+        - os: linux
+          compiler: gcc
+          sudo: required
+          dist: trusty
+          env: QTC_VER=4.7 QTC_DL=linux_gcc_64_rhel72
         - os: osx
           compiler: clang
           env: QTC_VER=4.2 QTC_DL=mac_x64
@@ -26,6 +41,15 @@ matrix:
         - os: osx
           compiler: clang
           env: QTC_VER=4.4 QTC_DL=mac_x64
+        - os: osx
+          compiler: clang
+          env: QTC_VER=4.5 QTC_DL=mac_x64
+        - os: osx
+          compiler: clang
+          env: QTC_VER=4.6 QTC_DL=mac_x64
+        - os: osx
+          compiler: clang
+          env: QTC_VER=4.7 QTC_DL=mac_x64
 
 install:
     - scripts/install.sh


### PR DESCRIPTION
add builds for QTC 4.5, 4.6 and 4.7 to CI build pipelines for windows, mac and linux