### PR TITLE
extend CI to build for Qt Creator 4.11.x

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,6 +61,14 @@ environment:
       QTC_VER: 4.10
       VS_VER: 2017
 
+    - platform: x86
+      QTC_VER: 4.11
+      VS_VER: 2017
+
+    - platform: x64
+      QTC_VER: 4.11
+      VS_VER: 2017
+
 configuration:
   - Release
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,11 @@ matrix:
           sudo: required
           dist: trusty
           env: QTC_VER=4.10 QTC_DL=linux_gcc_64_rhel72
+        - os: linux
+          compiler: gcc
+          sudo: required
+          dist: trusty
+          env: QTC_VER=4.11 QTC_DL=linux_gcc_64_rhel72
           
         - os: osx
           compiler: clang
@@ -51,6 +56,9 @@ matrix:
         - os: osx
           compiler: clang
           env: QTC_VER=4.10 QTC_DL=mac_x64
+        - os: osx
+          compiler: clang
+          env: QTC_VER=4.11 QTC_DL=mac_x64
 
 install:
     - scripts/install.sh

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Windows Builds: [![Build status](https://ci.appveyor.com/api/projects/status/6lu
 Qt Creator Plugin for communication with [Sourcetrail](https://sourcetrail.com)
 
 Supported Qt Creator Versions:
+* Qt Creator 4.11.x
 * Qt Creator 4.10.x
 * Qt Creator 4.9.x
 * Qt Creator 4.8.x


### PR DESCRIPTION
QtCreator 4.11 is released since 2019-12-12
https://www.qt.io/blog/qt-creator-4.11.0-is-released